### PR TITLE
Add getter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Metadata getter method for `SpectrumDocument` [#50](https://github.com/iomega/spec2vec/pull/50)
 
+### Changed
+
+- Change default for `n_decimals` parameter from 1 to 2 [#50](https://github.com/iomega/spec2vec/pull/50)
+
 ## [0.3.2] - 2020-12-03
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Metadata getter method for `SpectrumDocument` [#50](https://github.com/iomega/spec2vec/pull/50)
+
 ## [0.3.2] - 2020-12-03
 
 ### Changed

--- a/integration-tests/test_user_workflow_spec2vec.py
+++ b/integration-tests/test_user_workflow_spec2vec.py
@@ -43,7 +43,7 @@ def test_user_workflow_spec2vec():
     # omit spectrums that didn't qualify for analysis
     spectrums = [s for s in spectrums if s is not None]
 
-    documents = [SpectrumDocument(s) for s in spectrums]
+    documents = [SpectrumDocument(s, n_decimals=1) for s in spectrums]
 
     model_file = os.path.join(repository_root, "integration-tests", "test_user_workflow_spec2vec.model")
     if os.path.isfile(model_file):

--- a/spec2vec/SpectrumDocument.py
+++ b/spec2vec/SpectrumDocument.py
@@ -35,7 +35,7 @@ class SpectrumDocument(Document):
     .. testoutput::
 
         ['peak@100.0', 'peak@150.0', 'peak@200.5']
-        [100.  150.  200.51]
+        [100.   150.   200.51]
         substance1
     """
     def __init__(self, spectrum, n_decimals: int = 2):

--- a/spec2vec/SpectrumDocument.py
+++ b/spec2vec/SpectrumDocument.py
@@ -1,3 +1,5 @@
+from typing import Optional
+from matchms.Spikes import Spikes
 from .Document import Document
 
 

--- a/spec2vec/SpectrumDocument.py
+++ b/spec2vec/SpectrumDocument.py
@@ -12,7 +12,7 @@ class SpectrumDocument(Document):
     Peaks with identical resulting strings will not be merged, hence same words can
     exist multiple times in a document (e.g. peaks at 100.31 and 100.29 would lead to
     two words "peak@100.3" when using n_decimals=1).
-    
+
     For example:
 
     .. testcode::
@@ -25,7 +25,7 @@ class SpectrumDocument(Document):
                             intensities=np.array([0.7, 0.2, 0.1]),
                             metadata={'compound_name': 'substance1'})
         spectrum_document = SpectrumDocument(spectrum, n_decimals=2)
-        
+
         print(spectrum_document.words)
         print(spectrum_document.peaks.mz)
         print(spectrum_document.get("compound_name"))

--- a/spec2vec/SpectrumDocument.py
+++ b/spec2vec/SpectrumDocument.py
@@ -24,7 +24,7 @@ class SpectrumDocument(Document):
         spectrum = Spectrum(mz=np.array([100.0, 150.0, 200.51]),
                             intensities=np.array([0.7, 0.2, 0.1]),
                             metadata={'compound_name': 'substance1'})
-        spectrum_document = SpectrumDocument(spectrum, n_decimals=2)
+        spectrum_document = SpectrumDocument(spectrum, n_decimals=1)
 
         print(spectrum_document.words)
         print(spectrum_document.peaks.mz)

--- a/spec2vec/SpectrumDocument.py
+++ b/spec2vec/SpectrumDocument.py
@@ -8,12 +8,37 @@ class SpectrumDocument(Document):
 
     Every peak (and loss) positions (m/z value) will be converted into a string "word".
     The entire list of all peak words forms a spectrum document. Peak words have
-    the form "peak@100.3" (for n_decimals=1), and losses have the format "loss@100.3".
+    the form "peak@100.32" (for n_decimals=2), and losses have the format "loss@100.32".
     Peaks with identical resulting strings will not be merged, hence same words can
     exist multiple times in a document (e.g. peaks at 100.31 and 100.29 would lead to
     two words "peak@100.3" when using n_decimals=1).
+    
+    For example:
+
+    .. testcode::
+
+        import numpy as np
+        from matchms import Spectrum
+        from spec2vec import SpectrumDocument
+
+        spectrum = Spectrum(mz=np.array([100.0, 150.0, 200.51]),
+                            intensities=np.array([0.7, 0.2, 0.1]),
+                            metadata={'compound_name': 'substance1'})
+        spectrum_document = SpectrumDocument(spectrum, n_decimals=2)
+        
+        print(spectrum_document.words)
+        print(spectrum_document.peaks.mz)
+        print(spectrum_document.get("compound_name"))
+
+    Should output
+
+    .. testoutput::
+
+        ['peak@100.0', 'peak@150.0', 'peak@200.5']
+        [100.  150.  200.51]
+        substance1
     """
-    def __init__(self, spectrum, n_decimals: int = 1):
+    def __init__(self, spectrum, n_decimals: int = 2):
         """
 
         Parameters
@@ -22,8 +47,8 @@ class SpectrumDocument(Document):
             Input spectrum.
         n_decimals
             Peak positions are converted to strings with n_decimal decimals.
-            The default is 1, which would convert a peak at 100.381 into the
-            word "peak@100.4".
+            The default is 2, which would convert a peak at 100.387 into the
+            word "peak@100.39".
         """
         self.n_decimals = n_decimals
         self.weights = None

--- a/spec2vec/SpectrumDocument.py
+++ b/spec2vec/SpectrumDocument.py
@@ -60,4 +60,19 @@ class SpectrumDocument(Document):
 
         """
         assert not hasattr(self, key), "Key cannot be attribute of SpectrumDocument class"
-        return self._obj.metadata.copy().get(key, default)
+        return self._obj._metadata.copy().get(key, default)
+
+    @property
+    def metadata(self):
+        """Return metadata of original spectrum."""
+        return self._obj._metadata.copy()
+
+    @property
+    def losses(self) -> Optional[Spikes]:
+        """Return losses of original spectrum."""
+        return self._obj._losses.clone() if self._losses is not None else None
+
+    @property
+    def peaks(self) -> Spikes:
+        """Return peaks of original spectrum."""
+        return self._obj._peaks.clone()

--- a/spec2vec/SpectrumDocument.py
+++ b/spec2vec/SpectrumDocument.py
@@ -62,19 +62,19 @@ class SpectrumDocument(Document):
 
         """
         assert not hasattr(self, key), "Key cannot be attribute of SpectrumDocument class"
-        return self._obj._metadata.copy().get(key, default)
+        return self._obj.get(key, default)
 
     @property
     def metadata(self):
         """Return metadata of original spectrum."""
-        return self._obj._metadata.copy()
+        return self._obj.metadata
 
     @property
     def losses(self) -> Optional[Spikes]:
         """Return losses of original spectrum."""
-        return self._obj._losses.clone() if self._losses is not None else None
+        return self._obj.losses
 
     @property
     def peaks(self) -> Spikes:
         """Return peaks of original spectrum."""
-        return self._obj._peaks.clone()
+        return self._obj.peaks

--- a/spec2vec/SpectrumDocument.py
+++ b/spec2vec/SpectrumDocument.py
@@ -50,3 +50,14 @@ class SpectrumDocument(Document):
             loss_intensities = []
         self.weights = peak_intensities + loss_intensities
         return self
+
+    def get(self, key: str, default=None):
+        """Retrieve value from Spectrum metadata dict. Shorthand for
+
+        .. code-block:: python
+
+            val = self._obj.metadata[key]
+
+        """
+        assert not hasattr(self, key), "Key cannot be attribute of SpectrumDocument class"
+        return self._obj.metadata.copy().get(key, default)

--- a/tests/test_spec2vec.py
+++ b/tests/test_spec2vec.py
@@ -16,7 +16,7 @@ def test_spec2vec_pair_method():
                           intensities=numpy.array([0.4, 0.2, 0.1]),
                           metadata={'id': 'spectrum2'})
 
-    documents = [SpectrumDocument(s) for s in [spectrum_1, spectrum_2]]
+    documents = [SpectrumDocument(s, n_decimals=1) for s in [spectrum_1, spectrum_2]]
     model = load_test_model()
     spec2vec = Spec2Vec(model=model, intensity_weighting_power=0.5)
     score01 = spec2vec.pair(documents[0], documents[1])
@@ -37,7 +37,7 @@ def test_spec2vec_matrix_method(progress_bar):
                           intensities=numpy.array([0.4, 0.2, 0.1]),
                           metadata={'id': 'spectrum2'})
 
-    documents = [SpectrumDocument(s) for s in [spectrum_1, spectrum_2]]
+    documents = [SpectrumDocument(s, n_decimals=1) for s in [spectrum_1, spectrum_2]]
     model = load_test_model()
     spec2vec = Spec2Vec(model=model, intensity_weighting_power=0.5, progress_bar=progress_bar)
     scores = spec2vec.matrix(documents, documents)

--- a/tests/test_spectrum_document.py
+++ b/tests/test_spectrum_document.py
@@ -82,6 +82,7 @@ def test_spectrum_document_metadata_getter():
 
     assert spectrum_document.n_decimals == 2
     assert len(spectrum_document) == 4
+    assert spectrum_document.metadata == metadata, "Expected different metadata"
     assert spectrum_document.get("smiles") == "testsmiles", "Expected different metadata"
     assert spectrum_document.words == [
         "peak@10.00", "peak@20.00", "peak@30.00", "peak@40.00"
@@ -102,3 +103,32 @@ def test_spectrum_document_metadata_getter_notallowed_key():
         spectrum_document.get("n_decimals")
 
     assert str(msg.value) == "Key cannot be attribute of SpectrumDocument class"
+
+
+def test_spectrum_document_peak_getter():
+    """Test peak getter"""
+    mz = numpy.array([10, 20, 30, 40], dtype="float")
+    intensities = numpy.array([0, 0.01, 0.1, 1], dtype="float")
+    metadata = {"precursor_mz": 100.0}
+    spectrum_in = Spectrum(mz=mz, intensities=intensities, metadata=metadata)
+    spectrum_document = SpectrumDocument(spectrum_in, n_decimals=2)
+
+    assert spectrum_document.words == [
+        "peak@10.00", "peak@20.00", "peak@30.00", "peak@40.00"
+    ]
+    assert numpy.all(spectrum_document.peaks.mz == mz), "Expected different peak m/z"
+    assert numpy.all(spectrum_document.peaks.intensities == intensities), "Expected different peaks"
+
+
+def test_spectrum_document_losses_getter():
+    """Test losses getter"""
+    mz = numpy.array([10, 20, 30, 40], dtype="float")
+    intensities = numpy.array([0, 0.01, 0.1, 1], dtype="float")
+    metadata = {"precursor_mz": 100.0}
+    spectrum_in = Spectrum(mz=mz, intensities=intensities, metadata=metadata)
+    spectrum = add_losses(spectrum_in)
+    spectrum_document = SpectrumDocument(spectrum, n_decimals=2)
+    assert numpy.all(spectrum_document.losses.mz == numpy.array([60., 70., 80., 90.])), \
+        "Expected different losses"
+    assert numpy.all(spectrum_document.losses.intensities == intensities[::-1]), \
+        "Expected different losses"

--- a/tests/test_spectrum_document.py
+++ b/tests/test_spectrum_document.py
@@ -16,9 +16,9 @@ def test_spectrum_document_init_n_decimals_default_value_no_losses():
     assert spectrum_document.n_decimals == 2, "Expected different default for n_decimals"
     assert len(spectrum_document) == 4
     assert spectrum_document.words == [
-        "peak@10.0", "peak@20.0", "peak@30.0", "peak@40.0"
+        "peak@10.00", "peak@20.00", "peak@30.00", "peak@40.00"
     ]
-    assert next(spectrum_document) == "peak@10.0"
+    assert next(spectrum_document) == "peak@10.00"
 
 
 def test_spectrum_document_init_n_decimals_1_no_losses():
@@ -28,7 +28,7 @@ def test_spectrum_document_init_n_decimals_1_no_losses():
     spectrum = Spectrum(mz=mz, intensities=intensities, metadata=metadata)
     spectrum_document = SpectrumDocument(spectrum, n_decimals=1)
 
-    assert spectrum_document.n_decimals == 2
+    assert spectrum_document.n_decimals == 1
     assert len(spectrum_document) == 4
     assert spectrum_document.words == [
         "peak@10.0", "peak@20.0", "peak@30.0", "peak@40.0"

--- a/tests/test_spectrum_document.py
+++ b/tests/test_spectrum_document.py
@@ -1,4 +1,5 @@
 import numpy
+import pytest
 from matchms import Spectrum
 from matchms.filtering import add_losses
 from spec2vec import SpectrumDocument

--- a/tests/test_spectrum_document.py
+++ b/tests/test_spectrum_document.py
@@ -13,7 +13,7 @@ def test_spectrum_document_init_n_decimals_default_value_no_losses():
     spectrum = Spectrum(mz=mz, intensities=intensities, metadata=metadata)
     spectrum_document = SpectrumDocument(spectrum)
 
-    assert spectrum_document.n_decimals == 1
+    assert spectrum_document.n_decimals == 2, "Expected different default for n_decimals"
     assert len(spectrum_document) == 4
     assert spectrum_document.words == [
         "peak@10.0", "peak@20.0", "peak@30.0", "peak@40.0"
@@ -21,29 +21,47 @@ def test_spectrum_document_init_n_decimals_default_value_no_losses():
     assert next(spectrum_document) == "peak@10.0"
 
 
-def test_spectrum_document_init_n_decimals_2_no_losses():
+def test_spectrum_document_init_n_decimals_1_no_losses():
     mz = numpy.array([10, 20, 30, 40], dtype="float")
     intensities = numpy.array([0, 0.01, 0.1, 1], dtype="float")
     metadata = dict(precursor_mz=100.0)
     spectrum = Spectrum(mz=mz, intensities=intensities, metadata=metadata)
-    spectrum_document = SpectrumDocument(spectrum, n_decimals=2)
+    spectrum_document = SpectrumDocument(spectrum, n_decimals=1)
 
     assert spectrum_document.n_decimals == 2
     assert len(spectrum_document) == 4
     assert spectrum_document.words == [
-        "peak@10.00", "peak@20.00", "peak@30.00", "peak@40.00"
+        "peak@10.0", "peak@20.0", "peak@30.0", "peak@40.0"
     ]
-    assert next(spectrum_document) == "peak@10.00"
+    assert next(spectrum_document) == "peak@10.0"
 
 
-def test_spectrum_document_init_n_decimals_default_value():
-
+def test_spectrum_document_init_default_with_losses():
+    """Use default n_decimal and add losses."""
     mz = numpy.array([10, 20, 30, 40], dtype="float")
     intensities = numpy.array([0, 0.01, 0.1, 1], dtype="float")
     metadata = dict(precursor_mz=100.0)
     spectrum_in = Spectrum(mz=mz, intensities=intensities, metadata=metadata)
     spectrum = add_losses(spectrum_in)
     spectrum_document = SpectrumDocument(spectrum)
+
+    assert spectrum_document.n_decimals == 2, "Expected different default for n_decimals"
+    assert len(spectrum_document) == 8
+    assert spectrum_document.words == [
+        "peak@10.00", "peak@20.00", "peak@30.00", "peak@40.00",
+        "loss@60.00", "loss@70.00", "loss@80.00", "loss@90.00"
+    ]
+    assert next(spectrum_document) == "peak@10.00"
+
+
+def test_spectrum_document_init_n_decimals_1():
+    """Use n_decimal=1 and add losses."""
+    mz = numpy.array([10, 20, 30, 40], dtype="float")
+    intensities = numpy.array([0, 0.01, 0.1, 1], dtype="float")
+    metadata = dict(precursor_mz=100.0)
+    spectrum_in = Spectrum(mz=mz, intensities=intensities, metadata=metadata)
+    spectrum = add_losses(spectrum_in)
+    spectrum_document = SpectrumDocument(spectrum, n_decimals=1)
 
     assert spectrum_document.n_decimals == 1
     assert len(spectrum_document) == 8
@@ -52,23 +70,6 @@ def test_spectrum_document_init_n_decimals_default_value():
         "loss@60.0", "loss@70.0", "loss@80.0", "loss@90.0"
     ]
     assert next(spectrum_document) == "peak@10.0"
-
-
-def test_spectrum_document_init_n_decimals_2():
-    mz = numpy.array([10, 20, 30, 40], dtype="float")
-    intensities = numpy.array([0, 0.01, 0.1, 1], dtype="float")
-    metadata = dict(precursor_mz=100.0)
-    spectrum_in = Spectrum(mz=mz, intensities=intensities, metadata=metadata)
-    spectrum = add_losses(spectrum_in)
-    spectrum_document = SpectrumDocument(spectrum, n_decimals=2)
-
-    assert spectrum_document.n_decimals == 2
-    assert len(spectrum_document) == 8
-    assert spectrum_document.words == [
-        "peak@10.00", "peak@20.00", "peak@30.00", "peak@40.00",
-        "loss@60.00", "loss@70.00", "loss@80.00", "loss@90.00"
-    ]
-    assert next(spectrum_document) == "peak@10.00"
 
 
 def test_spectrum_document_metadata_getter():

--- a/tests/test_spectrum_document.py
+++ b/tests/test_spectrum_document.py
@@ -68,3 +68,36 @@ def test_spectrum_document_init_n_decimals_2():
         "loss@60.00", "loss@70.00", "loss@80.00", "loss@90.00"
     ]
     assert next(spectrum_document) == "peak@10.00"
+
+
+def test_spectrum_document_metadata_getter():
+    """Test metadata getter"""
+    mz = numpy.array([10, 20, 30, 40], dtype="float")
+    intensities = numpy.array([0, 0.01, 0.1, 1], dtype="float")
+    metadata = {"precursor_mz": 100.0,
+                "smiles": "testsmiles"}
+    spectrum_in = Spectrum(mz=mz, intensities=intensities, metadata=metadata)
+    spectrum_document = SpectrumDocument(spectrum_in, n_decimals=2)
+
+    assert spectrum_document.n_decimals == 2
+    assert len(spectrum_document) == 4
+    assert spectrum_document.get("smiles") == "testsmiles", "Expected different metadata"
+    assert spectrum_document.words == [
+        "peak@10.00", "peak@20.00", "peak@30.00", "peak@40.00"
+    ]
+    assert next(spectrum_document) == "peak@10.00"
+
+
+def test_spectrum_document_metadata_getter_notallowed_key():
+    """Test metadata getter with key that is also attribute"""
+    mz = numpy.array([10], dtype="float")
+    intensities = numpy.array([0], dtype="float")
+    metadata = {"smiles": "testsmiles"}
+    spectrum_in = Spectrum(mz=mz, intensities=intensities, metadata=metadata)
+    spectrum_document = SpectrumDocument(spectrum_in, n_decimals=2)
+
+    assert spectrum_document.n_decimals == 2
+    with pytest.raises(AssertionError) as msg:
+        spectrum_document.get("n_decimals")
+
+    assert str(msg.value) == "Key cannot be attribute of SpectrumDocument class"


### PR DESCRIPTION
Address #49, for which I here added getters to `SpectrumDocument` for:
- `.metadata` --> points to `SpectrumDocument._obj.metadata`
- `.get()` --> points to `SpectrumDocument._obj.get()`
- `.peaks` --> points to `SpectrumDocument._obj.peaks`
- `.losses` --> points to `SpectrumDocument._obj.losses`

[edit] I also changed one parameter default (`n_decimals=2`) since that is what we usually use and what all our provided pretrained models will expect.