### PR TITLE
Fix CI failing for Python 3.8 & 3.9 on ubuntu-latest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- bumped **gensim** version to `>=4.2.0` in dependencies
+- bumped **gensim** version to `>=4.2.0` in dependencies [#84](https://github.com/iomega/spec2vec/pull/84)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - added `spec2vec.serialization` subpackage to import and export `Word2Vec` models to/from disk without Pickle 
   (via `import_model` and `export_model` respectively) [#80](https://github.com/iomega/spec2vec/pull/80)
 
-## Fixed
+### Changed
+
+- bumped **gensim** version to `>=4.2.0` in dependencies
+
+### Fixed
 
 - updated Code examples in documentation to recent changes in matchms.
 

--- a/conda/environment-dev.yml
+++ b/conda/environment-dev.yml
@@ -5,7 +5,7 @@ channels:
   - defaults
   - nlesc
 dependencies:
-  - gensim >=3.8.0
+  - gensim >=4.2.0
   - matchms >=0.6.2
   - numba >=0.51
   - numpy

--- a/conda/environment.yml
+++ b/conda/environment.yml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - gensim >=3.8.0
+  - gensim >=4.2.0
   - matchms >=0.6.2
   - numba >=0.51
   - numpy

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -36,7 +36,7 @@ requirements:
     - pytest-runner
     - setuptools
   run:
-    - gensim >=3.8.0
+    - gensim >=4.2.0
     - matchms >=0.6.0
     - numba >=0.51
     - numpy

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
     test_suite="tests",
     python_requires='>=3.7',
     install_requires=[
-        "gensim >=4.0.0",
+        "gensim >=4.2.0",
         "matchms >=0.11.0",
         "numba >=0.51",
         "numpy",


### PR DESCRIPTION
### Description

**Anaconda verify** CI workflow failed with Python 3.8 and 3.9 on ubuntu-latest after changes introduced by #80 and #81. The reason for this bug was that Conda resolver installed **gensim** `v4.1.2` in these workflows as opposed to `v4.2.0` in the rest of the workflows. **Gensim** `v4.2.0` [fixed](https://github.com/RaRe-Technologies/gensim/pull/3117) a bug that occurred in `v4.1.2` and caused the tests to fail.

### Changes

* bumped **gensim** version to `4.2.0` in requirements

Closes #83 